### PR TITLE
added PUT method to mock_single_request method

### DIFF
--- a/mockserver_client/mock_requests_loader.py
+++ b/mockserver_client/mock_requests_loader.py
@@ -172,6 +172,35 @@ def mock_single_request(
             timing=times(1),
             file_path=file_path,
         )
+    elif method == "PUT":
+        id_ = fhir_request["id"]
+        # noinspection PyPep8Naming
+        resourceType = fhir_request["resourceType"]
+        path = f"{('/' + url_prefix) if url_prefix else ''}/4_0_0/{resourceType}/{id_}"
+        payload: str = (
+            json.dumps(
+                [
+                    {
+                        "id": id_,
+                        "updated": False,
+                        "created": True,
+                        "resourceType": resourceType,
+                    }
+                ]
+            )
+            if not response_body
+            else response_body
+        )
+        mock_client.expect(
+            request=mock_request(
+                method="PUT",
+                path=path,
+                body=json_equals(fhir_request),
+            ),
+            response=mock_response(body=payload),
+            timing=times(1),
+            file_path=file_path,
+        )
     else:
         if not relative_path:
             id_ = fhir_request["id"]

--- a/mockserver_client/mock_requests_loader.py
+++ b/mockserver_client/mock_requests_loader.py
@@ -177,7 +177,8 @@ def mock_single_request(
         # noinspection PyPep8Naming
         resourceType = fhir_request["resourceType"]
         path = f"{('/' + url_prefix) if url_prefix else ''}/4_0_0/{resourceType}/{id_}"
-        payload: str = (
+
+        payload = (
             json.dumps(
                 [
                     {
@@ -191,6 +192,7 @@ def mock_single_request(
             if not response_body
             else response_body
         )
+
         mock_client.expect(
             request=mock_request(
                 method="PUT",

--- a/mockserver_client/mock_requests_loader.py
+++ b/mockserver_client/mock_requests_loader.py
@@ -183,8 +183,8 @@ def mock_single_request(
                 [
                     {
                         "id": id_,
-                        "updated": False,
-                        "created": True,
+                        "updated": True,
+                        "created": False,
                         "resourceType": resourceType,
                     }
                 ]


### PR DESCRIPTION
this is to support the PUT method call to reset FHIR resources, such as Compositions, on needed-basis