### PR TITLE
remove setup-pipenv from github workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,11 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Sync Pipfile with setup.py
-      run: |
-        python -m pip install --no-cache-dir pipenv
-        pipenv sync --dev --system
-        pipenv-setup sync --pipfile
     - name: Get Previous tag
       id: previoustag
       uses: WyriHaximus/github-action-get-previous-tag@master


### PR DESCRIPTION
It was causing issues with updating other dependencies so I removed setup-pipenv. This project does not really need it because we only require 3 packages and we don't pin them to a particular version.  